### PR TITLE
proper use of react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^0.13.2"
   },
   "scripts": {
-    "dev": "webpack-dev-server --config webpack.config.dev.js --inline --progress --colors --content-base public --history-api-fallback",
+    "dev": "webpack-dev-server --config webpack.config.dev.js --inline --progress --colors --content-base public --history-api-fallback --hot",
     "build": "webpack --config webpack.config.build.js --progress --colors",
     "test": "karma start"
   }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -14,7 +14,6 @@ config.module.loaders.push({
     exclude: /node_modules/
 });
 
-config.plugins.push(new webpack.HotModuleReplacementPlugin());
 config.plugins.push(new webpack.NoErrorsPlugin());
 
 module.exports = config;


### PR DESCRIPTION
Hot reloading now preserve the state of React components.

HMR plugin removed. Explained here
https://github.com/gaearon/react-hot-loader/issues/77
